### PR TITLE
sender: switch to d3d12 screen capture

### DIFF
--- a/sdk/mirroring_core/src/lib.rs
+++ b/sdk/mirroring_core/src/lib.rs
@@ -61,7 +61,7 @@ pub enum VideoSource {
         name: String,
     },
     #[cfg(target_os = "windows")]
-    D3d11Monitor {
+    D3d12Monitor {
         name: String,
         handle: u64,
     },
@@ -81,7 +81,7 @@ impl VideoSource {
             #[cfg(target_os = "macos")]
             VideoSource::CgDisplay { name, .. } => name.clone(),
             #[cfg(target_os = "windows")]
-            VideoSource::D3d11Monitor { name, .. } => name.clone(),
+            VideoSource::D3d12Monitor { name, .. } => name.clone(),
             #[cfg(target_os = "android")]
             VideoSource::Source(_) => "Default".to_owned(),
         }

--- a/sdk/mirroring_core/src/preview.rs
+++ b/sdk/mirroring_core/src/preview.rs
@@ -62,8 +62,8 @@ fn make_capture_src(src: VideoSource) -> Result<(gst::Element, Option<ExtraVideo
             None,
         ),
         #[cfg(target_os = "windows")]
-        VideoSource::D3d11Monitor { handle, .. } => (
-            gst::ElementFactory::make("d3d11screencapturesrc")
+        VideoSource::D3d12Monitor { handle, .. } => (
+            gst::ElementFactory::make("d3d12screencapturesrc")
                 .property("show-cursor", true)
                 .property("monitor-handle", handle)
                 .build()?,

--- a/sdk/mirroring_core/src/transmission.rs
+++ b/sdk/mirroring_core/src/transmission.rs
@@ -534,7 +534,7 @@ impl WhepSink {
                     .ok_or(anyhow::anyhow!("Source element is missing factory"))?
                     .name();
                 name == "ximagesrc"
-                    || name == "d3d11screencapturesrc"
+                    || name == "d3d12screencapturesrc"
                     || name == "avfvideosrc"
                     || name == "pipewiresrc"
                     || name == "videotestsrc"

--- a/senders/desktop/src/main.rs
+++ b/senders/desktop/src/main.rs
@@ -541,14 +541,14 @@ async fn spawn_video_source_fetcher(event_tx: UnboundedSender<Event>) -> Sender<
                     FetchEvent::Fetch => {
                         use gst::prelude::*;
                         let Some(dev_provider) =
-                            gst::DeviceProviderFactory::by_name("d3d11screencapturedeviceprovider")
+                            gst::DeviceProviderFactory::by_name("d3d12screencapturedeviceprovider")
                         else {
-                            error!("Failed to create `d3d11screencapturedeviceprovider`");
+                            error!("Failed to create `d3d12screencapturedeviceprovider`");
                             continue;
                         };
 
                         if let Err(err) = dev_provider.start() {
-                            error!("Failed to start d3d11 device provider: {err}");
+                            error!("Failed to start d3d12 device provider: {err}");
                             continue;
                         }
                         let devs = dev_provider.devices();
@@ -571,7 +571,7 @@ async fn spawn_video_source_fetcher(event_tx: UnboundedSender<Event>) -> Sender<
                                     continue;
                                 }
                             };
-                            converted_devs.push((idx, VideoSource::D3d11Monitor { name, handle }));
+                            converted_devs.push((idx, VideoSource::D3d12Monitor { name, handle }));
                         }
 
                         event_tx

--- a/xtask/src/sender.rs
+++ b/xtask/src/sender.rs
@@ -15,7 +15,7 @@ use xshell::Shell;
 use crate::{sh, workspace, AndroidAbiTarget};
 
 #[cfg(target_os = "windows")]
-const GSTREAMER_BASE_LIBS: [&'static str; 19] = [
+const GSTREAMER_BASE_LIBS: [&'static str; 20] = [
     "gstbase",
     "gstnet",
     "gstreamer",
@@ -29,6 +29,7 @@ const GSTREAMER_BASE_LIBS: [&'static str; 19] = [
     "gstwebrtc",
     "gstwebrtcnice",
     "gstd3d11",
+    "gstd3d12",
     "gstd3dshader",
     "gstaudio",
     "gsttag",
@@ -74,7 +75,7 @@ const GSTREAMER_PLUGIN_LIBS_COMMON: [&'static str; 13] = [
 ];
 
 #[cfg(target_os = "windows")]
-const GSTREAMER_PLUGIN_LIBS_WIN: [&'static str; 1] = ["gstd3d11"];
+const GSTREAMER_PLUGIN_LIBS_WIN: [&'static str; 2] = ["gstd3d11", "gstd3d12"];
 
 #[cfg(target_os = "macos")]
 const GSTREAMER_PLUGIN_LIBS_MACOS: [&'static str; 1] = ["gstapplemedia"];


### PR DESCRIPTION
Followup from https://github.com/futo-org/fcast/issues/72#issuecomment-3950193696.

This PR swaps the d3d11 gstreamer elements with their d3d12 equivalents. This allows FCast Sender to mirror HDR screens without washing out the screen's bright colors.

Notes:
- I've tested removing the gstd3d11 dll from xtask/src/sender.rs and replacing it with the gstd3d12 dll, but doing so seems to empty out the monitor selection list.