### PR TITLE
Fix rustls crypto panic on mac/win and handle missing volume status o…

### DIFF
--- a/crates/google-cast-protocol/src/lib.rs
+++ b/crates/google-cast-protocol/src/lib.rs
@@ -354,7 +354,7 @@ pub struct VolumeStatus {
 pub struct Status {
     pub applications: Option<Vec<Application>>,
     // TODO: `userEq`
-    pub volume: VolumeStatus,
+    pub volume: Option<VolumeStatus>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/sdk/sender/fcast-sender-sdk/src/chromecast.rs
+++ b/sdk/sender/fcast-sender-sdk/src/chromecast.rs
@@ -537,7 +537,9 @@ impl InnerDevice {
                         }
                         shared_state.is_running = new_is_running;
                         if shared_state.is_running {
-                            changed!(volume, status.volume.level, volume_changed);
+                            if let Some(volume_status) = &status.volume {
+                                changed!(volume, volume_status.level, volume_changed);
+                            }
                         } else {
                             self.launch_app().await?;
                         }

--- a/senders/desktop/Cargo.toml
+++ b/senders/desktop/Cargo.toml
@@ -35,6 +35,7 @@ url = "2"
 file-server = { path = "../../crates/file-server" }
 num_cpus.workspace = true
 mimalloc.workspace = true
+rustls = { version = "0.23.36", default-features = false, features = [ "prefer-post-quantum", "tls12", "std", "ring" ]}
 
 [dependencies.fcast-sender-sdk]
 path = "../../sdk/sender/fcast-sender-sdk"
@@ -48,7 +49,6 @@ winresource = "0.1.28"
 [target.'cfg(target_os = "linux")'.dependencies]
 ashpd = { version = "0.12.1", default-features = false, features = ["async-std"] } # `tokio` breaks slint
 xcb = { version = "1.6.0", features = ["randr", "xlib_xcb"] }
-rustls = { version = "0.23.36", default-features = false, features = [ "prefer-post-quantum", "tls12", "std", "ring" ]}
 reqwest = { version = "0.13", default-features = false, features = [ "charset", "http2", "system-proxy", "rustls-no-provider" ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/senders/desktop/src/main.rs
+++ b/senders/desktop/src/main.rs
@@ -2481,7 +2481,6 @@ fn main() -> Result<()> {
         .with(vec_layer)
         .init();
 
-    #[cfg(target_os = "linux")]
     if let Err(err) = rustls::crypto::ring::default_provider().install_default() {
         error!(
             ?err,


### PR DESCRIPTION
…n LG webOS TVs

- Installs Ring crypto provider universally on startup instead of Linux-only, resolving Rustls 0.23 panics during Chromecast handshakes on macOS and Windows.
- Relaxes the Chromecast protocol parsing so the 'volume' field is optional, avoiding connection failures when casting to LG webOS TVs and other receiver implementations that don't send volume info.
- Uses official crates.io Slint packages to bypass inaccessible FUTO GitLab servers.

Fixes https://github.com/futo-org/fcast/issues/82