### PR TITLE
Fix DeviceDiscoverer: Bonsoir 7 macOS discovery (#115)

### DIFF
--- a/sdk/sender/flutter-plugin/lib/discovery.dart
+++ b/sdk/sender/flutter-plugin/lib/discovery.dart
@@ -55,6 +55,57 @@ List<IpAddr> _convertHostAddresses(List<String> hostAddresses) {
       .toList();
 }
 
+/// Stable key for deduplicating discovered devices and matching removals.
+///
+/// Chromecast receivers use the TXT `id` field (hardware id). FCast receivers
+/// use the display / mDNS name. A protocol prefix prevents collisions when the
+/// same friendly name appears on different stacks.
+String deviceStorageKey(DeviceInfo info) {
+  final txtId = info.txtRecords['id'];
+  if (txtId != null && txtId.isNotEmpty) {
+    return '${info.protocol.name}:$txtId';
+  }
+  return '${info.protocol.name}:${info.name}';
+}
+
+/// Resolves a Bonsoir service to IP addresses.
+///
+/// Bonsoir 7 populates [BonsoirService.hostAddresses] after a native resolve.
+/// When that resolve fails partially (common on macOS under concurrent
+/// resolves), fall back to [BonsoirService.hostname] + [InternetAddress.lookup]
+/// — the approach used by fcast_sender_sdk 0.0.3.
+Future<List<IpAddr>> _lookupHostAddresses(BonsoirService service) async {
+  if (service.hostAddresses.isNotEmpty) {
+    final addrs = _convertHostAddresses(service.hostAddresses);
+    if (addrs.isNotEmpty) {
+      return addrs;
+    }
+  }
+
+  final hostname = service.hostname;
+  if (hostname != null && hostname.isNotEmpty) {
+    final lookedUp = await InternetAddress.lookup(hostname);
+    return lookedUp.map(_internetAddressToIpAddr).whereType<IpAddr>().toList();
+  }
+
+  return const [];
+}
+
+/// One pending mDNS resolve job for the serialized resolve queue.
+class _PendingResolve {
+  _PendingResolve({
+    required this.protocol,
+    required this.service,
+    required this.resolver,
+    this.attempt = 1,
+  });
+
+  final String protocol;
+  final BonsoirService service;
+  final ServiceResolver resolver;
+  final int attempt;
+}
+
 class DiscoveryEvent {}
 
 class DiscoveryEventDeviceAdded extends DiscoveryEvent {
@@ -78,12 +129,15 @@ class DiscoveryEventDeviceUpdated extends DiscoveryEvent {
 }
 
 class DiscoveryEventDeviceRemoved extends DiscoveryEvent {
+  /// Storage key from [deviceStorageKey], not the raw mDNS instance name.
   final String name;
 
   DiscoveryEventDeviceRemoved({required this.name});
 }
 
 class DeviceDiscoverer {
+  static const _maxResolveAttempts = 4;
+
   final BonsoirDiscovery _fcastDiscovery = BonsoirDiscovery(
     type: '_fcast._tcp',
   );
@@ -91,13 +145,34 @@ class DeviceDiscoverer {
     type: '_googlecast._tcp',
   );
   final eventStreamController = StreamController();
-  final Set<String> _seenDevices = {};
+
+  // Dedupe by stable storage key instead of Chromecast friendly name alone.
+  final Set<String> _seenStorageKeys = {};
+
+  // Map mDNS instance name -> storage key so ServiceLost matches ServiceFound.
+  final Map<String, String> _mdnsNameToStorageKey = {};
+
+  // Serialized resolve queue: macOS DNSServiceResolve is unreliable when
+  // several Bonsoir resolves run concurrently across both browsers.
+  final Map<String, BonsoirService> _unresolvedByMdns = {};
+  final Map<String, int> _resolveAttemptsByMdns = {};
+  final List<_PendingResolve> _resolveQueue = [];
+  _PendingResolve? _inFlightResolve;
+  Timer? _resolveRetryTimer;
 
   DeviceDiscoverer();
 
-  void _deviceFoundOrUpdated(DeviceInfo deviceInfo, int? gcastCaps) {
-    if (_seenDevices.add(deviceInfo.name)) {
-      // Not seen
+  void _deviceFoundOrUpdated(
+    String mdnsServiceName,
+    DeviceInfo deviceInfo,
+    int? gcastCaps,
+  ) {
+    final storageKey = deviceStorageKey(deviceInfo);
+    _mdnsNameToStorageKey[mdnsServiceName] = storageKey;
+    _unresolvedByMdns.remove(mdnsServiceName);
+    _resolveAttemptsByMdns.remove(mdnsServiceName);
+
+    if (_seenStorageKeys.add(storageKey)) {
       eventStreamController.sink.add(
         DiscoveryEventDeviceAdded(deviceInfo: deviceInfo, gcastCaps: gcastCaps),
       );
@@ -111,105 +186,210 @@ class DeviceDiscoverer {
     }
   }
 
-  void _deviceRemoved(String name) {
-    _seenDevices.remove(name);
-    eventStreamController.sink.add(DiscoveryEventDeviceRemoved(name: name));
+  void _deviceRemoved(String mdnsServiceName) {
+    final storageKey = _mdnsNameToStorageKey.remove(mdnsServiceName);
+    _unresolvedByMdns.remove(mdnsServiceName);
+    _resolveAttemptsByMdns.remove(mdnsServiceName);
+    if (storageKey == null) {
+      return;
+    }
+    _seenStorageKeys.remove(storageKey);
+    eventStreamController.sink.add(
+      DiscoveryEventDeviceRemoved(name: storageKey),
+    );
+  }
+
+  void _enqueueResolve({
+    required String protocol,
+    required BonsoirService service,
+    required ServiceResolver resolver,
+    int attempt = 1,
+  }) {
+    if (service.hostAddresses.isNotEmpty) {
+      return;
+    }
+    if (_inFlightResolve?.service.name == service.name ||
+        _resolveQueue.any((job) => job.service.name == service.name)) {
+      return;
+    }
+
+    _unresolvedByMdns[service.name] = service;
+    _resolveAttemptsByMdns[service.name] = attempt;
+    _resolveQueue.add(
+      _PendingResolve(
+        protocol: protocol,
+        service: service,
+        resolver: resolver,
+        attempt: attempt,
+      ),
+    );
+    _pumpResolveQueue();
+  }
+
+  void _pumpResolveQueue() {
+    if (_inFlightResolve != null || _resolveQueue.isEmpty) {
+      return;
+    }
+    final job = _resolveQueue.removeAt(0);
+    _inFlightResolve = job;
+    unawaited(job.service.resolve(job.resolver));
+  }
+
+  void _completeInFlightResolve({String? mdnsName}) {
+    final inFlight = _inFlightResolve;
+    if (inFlight == null) {
+      return;
+    }
+    if (mdnsName != null && inFlight.service.name != mdnsName) {
+      return;
+    }
+    _inFlightResolve = null;
+    _pumpResolveQueue();
+  }
+
+  void _retryResolve(String protocol, String mdnsName) {
+    final service = _unresolvedByMdns[mdnsName];
+    final resolver = protocol == 'chromecast'
+        ? _chromecastDiscovery.serviceResolver
+        : _fcastDiscovery.serviceResolver;
+    if (service == null) {
+      return;
+    }
+
+    final nextAttempt = (_resolveAttemptsByMdns[mdnsName] ?? 0) + 1;
+    if (nextAttempt > _maxResolveAttempts) {
+      _unresolvedByMdns.remove(mdnsName);
+      _resolveAttemptsByMdns.remove(mdnsName);
+      return;
+    }
+
+    _resolveRetryTimer?.cancel();
+    _resolveRetryTimer = Timer(
+      Duration(milliseconds: 250 * nextAttempt),
+      () => _enqueueResolve(
+        protocol: protocol,
+        service: service,
+        resolver: resolver,
+        attempt: nextAttempt,
+      ),
+    );
+  }
+
+  void _handleResolveFailed(String protocol, String? mdnsName) {
+    final targetName = mdnsName ?? _inFlightResolve?.service.name;
+    _completeInFlightResolve(mdnsName: targetName);
+    if (targetName != null) {
+      _retryResolve(protocol, targetName);
+    }
+  }
+
+  Future<void> _handleFcastEvent(BonsoirDiscoveryEvent event) async {
+    switch (event) {
+      case BonsoirDiscoveryServiceFoundEvent():
+        _enqueueResolve(
+          protocol: 'fCast',
+          service: event.service,
+          resolver: _fcastDiscovery.serviceResolver,
+        );
+      case BonsoirDiscoveryServiceResolvedEvent():
+        _completeInFlightResolve(mdnsName: event.service.name);
+        final deviceInfo = await _makeFcastDeviceInfo(event.service);
+        if (deviceInfo != null) {
+          _deviceFoundOrUpdated(event.service.name, deviceInfo, null);
+        }
+      case BonsoirDiscoveryServiceUpdatedEvent():
+        final deviceInfo = await _makeFcastDeviceInfo(event.service);
+        if (deviceInfo != null) {
+          _deviceFoundOrUpdated(event.service.name, deviceInfo, null);
+        }
+      case BonsoirDiscoveryServiceResolveFailedEvent():
+        _handleResolveFailed('fCast', event.service?.name);
+      case BonsoirDiscoveryServiceLostEvent():
+        _deviceRemoved(event.service.name);
+      default:
+        break;
+    }
+  }
+
+  Future<void> _handleChromecastEvent(BonsoirDiscoveryEvent event) async {
+    switch (event) {
+      case BonsoirDiscoveryServiceFoundEvent():
+        _enqueueResolve(
+          protocol: 'chromecast',
+          service: event.service,
+          resolver: _chromecastDiscovery.serviceResolver,
+        );
+      case BonsoirDiscoveryServiceResolvedEvent():
+        _completeInFlightResolve(mdnsName: event.service.name);
+        final service = await _makeChromecastDeviceInfo(event.service);
+        if (service != null) {
+          _deviceFoundOrUpdated(event.service.name, service.$1, service.$2);
+        }
+      case BonsoirDiscoveryServiceUpdatedEvent():
+        final service = await _makeChromecastDeviceInfo(event.service);
+        if (service != null) {
+          _deviceFoundOrUpdated(event.service.name, service.$1, service.$2);
+        }
+      case BonsoirDiscoveryServiceResolveFailedEvent():
+        _handleResolveFailed('chromecast', event.service?.name);
+      case BonsoirDiscoveryServiceLostEvent():
+        _deviceRemoved(event.service.name);
+      default:
+        break;
+    }
   }
 
   Future<DeviceInfo?> _makeFcastDeviceInfo(BonsoirService service) async {
-    if (service.hostAddresses.isNotEmpty) {
-      List<IpAddr> addrs = _convertHostAddresses(service.hostAddresses);
-      DeviceInfo deviceInfo = DeviceInfo(
-        name: service.name,
-        protocol: ProtocolType.fCast,
-        addresses: addrs,
-        port: service.port,
-        txtRecords: service.attributes,
-      );
-      return deviceInfo;
+    final addrs = await _lookupHostAddresses(service);
+    if (addrs.isEmpty) {
+      return null;
     }
-    return null;
+    return DeviceInfo(
+      name: service.name,
+      protocol: ProtocolType.fCast,
+      addresses: addrs,
+      port: service.port,
+      txtRecords: service.attributes,
+    );
   }
 
   Future<(DeviceInfo, int?)?> _makeChromecastDeviceInfo(
     BonsoirService service,
   ) async {
-    if (service.hostAddresses.isNotEmpty) {
-      List<IpAddr> addrs = _convertHostAddresses(service.hostAddresses);
-      // NOTE: fn = friendly name
-      String name = service.attributes['fn'] ?? service.name;
-      DeviceInfo deviceInfo = DeviceInfo(
+    final addrs = await _lookupHostAddresses(service);
+    if (addrs.isEmpty) {
+      return null;
+    }
+    // fn = friendly display name advertised in Chromecast TXT records.
+    final name = service.attributes['fn'] ?? service.name;
+    final capsStr = service.attributes['ca'];
+    final caps = capsStr != null ? int.tryParse(capsStr) : null;
+    return (
+      DeviceInfo(
         name: name,
         protocol: ProtocolType.chromecast,
         addresses: addrs,
         port: service.port,
         txtRecords: service.attributes,
-      );
-      String? capsStr = service.attributes["ca"];
-      int? caps = capsStr != null ? int.tryParse(capsStr) : null;
-      return (deviceInfo, caps);
-    }
-    return null;
+      ),
+      caps,
+    );
   }
 
   Future<void> init() async {
-    await _fcastDiscovery.initialize();
+    // Chromecast first: on macOS, FCast resolves were starving Chromecast
+    // browse when both browsers started simultaneously.
     await _chromecastDiscovery.initialize();
+    await _fcastDiscovery.initialize();
 
-    _fcastDiscovery.eventStream!.listen((event) async {
-      switch (event) {
-        case BonsoirDiscoveryServiceFoundEvent():
-          event.service.resolve(_fcastDiscovery.serviceResolver);
-          break;
-        case BonsoirDiscoveryServiceResolvedEvent():
-          DeviceInfo? deviceInfo = await _makeFcastDeviceInfo(event.service);
-          if (deviceInfo != null) {
-            _deviceFoundOrUpdated(deviceInfo, null);
-          }
-          break;
-        case BonsoirDiscoveryServiceUpdatedEvent():
-          DeviceInfo? deviceInfo = await _makeFcastDeviceInfo(event.service);
-          if (deviceInfo != null) {
-            _deviceFoundOrUpdated(deviceInfo, null);
-          }
-          break;
-        case BonsoirDiscoveryServiceLostEvent():
-          _deviceRemoved(event.service.name);
-          break;
-        default:
-          break;
-      }
-    });
     _chromecastDiscovery.eventStream!.listen((event) async {
-      switch (event) {
-        case BonsoirDiscoveryServiceFoundEvent():
-          event.service.resolve(_chromecastDiscovery.serviceResolver);
-          break;
-        case BonsoirDiscoveryServiceResolvedEvent():
-          (DeviceInfo, int?)? service = await _makeChromecastDeviceInfo(
-            event.service,
-          );
-          if (service != null) {
-            _deviceFoundOrUpdated(service.$1, service.$2);
-          }
-          break;
-        case BonsoirDiscoveryServiceUpdatedEvent():
-          (DeviceInfo, int?)? service = await _makeChromecastDeviceInfo(
-            event.service,
-          );
-          if (service != null) {
-            _deviceFoundOrUpdated(service.$1, service.$2);
-          }
-          break;
-        case BonsoirDiscoveryServiceLostEvent():
-          _deviceRemoved(event.service.name);
-          break;
-        default:
-          break;
-      }
+      await _handleChromecastEvent(event);
+    });
+    _fcastDiscovery.eventStream!.listen((event) async {
+      await _handleFcastEvent(event);
     });
 
-    await _fcastDiscovery.start();
     await _chromecastDiscovery.start();
+    await _fcastDiscovery.start();
   }
 }

--- a/sdk/sender/flutter-plugin/test/discovery_storage_key_test.dart
+++ b/sdk/sender/flutter-plugin/test/discovery_storage_key_test.dart
@@ -1,0 +1,33 @@
+import 'package:fcast_sender_sdk/fcast_sender_sdk.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('deviceStorageKey', () {
+    test('chromecast uses TXT id when present', () {
+      final info = DeviceInfo(
+        name: 'Our Bedroom',
+        protocol: ProtocolType.chromecast,
+        addresses: const [],
+        port: 8009,
+        txtRecords: const {'id': 'abc123', 'fn': 'Our Bedroom'},
+      );
+
+      expect(deviceStorageKey(info), 'chromecast:abc123');
+    });
+
+    test('fCast falls back to display name', () {
+      final info = DeviceInfo(
+        name: 'FCast-NVIDIA-SHIELD Android TV',
+        protocol: ProtocolType.fCast,
+        addresses: const [],
+        port: 46899,
+        txtRecords: const {'appVersion': '2.1.5'},
+      );
+
+      expect(
+        deviceStorageKey(info),
+        'fCast:FCast-NVIDIA-SHIELD Android TV',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes unreliable device discovery on multi-receiver LANs when using Bonsoir 7 (especially macOS), reported in #115.

Changes in `sdk/sender/flutter-plugin/lib/discovery.dart`:

- **Serialized resolve queue** — only one Bonsoir `resolve()` runs at a time across both `_fcast._tcp` and `_googlecast._tcp` browsers (macOS `DNSServiceResolve` fails under concurrent resolves)
- **Retry with backoff** — handles `BonsoirDiscoveryServiceResolveFailedEvent` and retries up to 4 times (250ms × attempt)
- **Hostname fallback** — when `hostAddresses` is empty, falls back to `InternetAddress.lookup(service.hostname)` (restores 0.0.3 resilience)
- **Stable storage keys** — new `deviceStorageKey()` helper; Chromecast dedupes by TXT `id`, FCast by display name; mDNS instance name mapped internally so `DiscoveryEventDeviceRemoved` matches add/dedup
- **Chromecast-first browse** — initialize and start `_googlecast._tcp` before `_fcast._tcp` to reduce resolve starvation on macOS

## API note

`DiscoveryEventDeviceRemoved.name` is now the **storage key** (e.g. `chromecast:abc123`), not the raw mDNS instance name. `DeviceInfo.name` on add/update events is unchanged.

## Test plan

- [x] `flutter analyze lib/discovery.dart` — clean
- [x] `flutter test test/discovery_storage_key_test.dart` — 2 tests pass
- [ ] Manual: macOS with 2+ Chromecasts + 2+ FCast advertisers on same LAN — all devices appear within ~10s

Closes #115